### PR TITLE
feat(UpdateActions): add limit to update actions

### DIFF
--- a/src/Error/Message.php
+++ b/src/Error/Message.php
@@ -35,5 +35,6 @@ class Message
     const DEPRECATED_METHOD = 'Call "%s" with method "%s" is deprecated: "%s"';
     const FUTURE_BAD_METHOD_CALL = 'Trying to call a function for a non future request';
 
-    const UPDATE_ACTION_LIMIT = 'Update call %s over limit of %s update actions';
+    const UPDATE_ACTION_LIMIT_WARNING = 'Update call %s has over %s update actions.';
+    const UPDATE_ACTION_LIMIT = 'Update call %s over limit of %s update actions.';
 }

--- a/src/Error/UpdateActionLimitException.php
+++ b/src/Error/UpdateActionLimitException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author @ct-jensschulze <jens.schulze@commercetools.de>
+ */
+
+namespace Commercetools\Core\Error;
+
+
+class UpdateActionLimitException extends \Exception
+{
+
+}

--- a/tests/unit/Request/AbstractUpdateRequestTest.php
+++ b/tests/unit/Request/AbstractUpdateRequestTest.php
@@ -100,12 +100,32 @@ class AbstractUpdateRequestTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->getUpdateRequest();
         $request->setContext(Context::of()->setLogger($logger));
-        for ($i = 0; $i <= 51; $i++) {
+        for ($i = 0; $i <= (AbstractUpdateRequest::ACTION_WARNING_TRESHOLD); $i++) {
             $request->addAction(['key' => 'value']);
         }
 
-        $logEntry = $handler->getRecords()[1];
+        $logEntry = $handler->getRecords()[0];
         $this->assertSame(Logger::WARNING, $logEntry['level']);
-        $this->assertSame('Update call test/id over limit of 50 update actions', $logEntry['message']);
+        $this->assertSame('Update call test/id has over 400 update actions.', $logEntry['message']);
+    }
+
+    public function testLogLimitNoException()
+    {
+        $request = $this->getUpdateRequest();
+        for ($i = 0; $i < (AbstractUpdateRequest::ACTION_MAX_LIMIT); $i++) {
+            $request->addAction(['key' => 'value']);
+        }
+        $this->assertCount(AbstractUpdateRequest::ACTION_MAX_LIMIT, $request->getActions());
+    }
+
+    /**
+     * @expectedException \Commercetools\Core\Error\UpdateActionLimitException
+     */
+    public function testLogLimitException()
+    {
+        $request = $this->getUpdateRequest();
+        for ($i = 0; $i <= (AbstractUpdateRequest::ACTION_MAX_LIMIT); $i++) {
+            $request->addAction(['key' => 'value']);
+        }
     }
 }


### PR DESCRIPTION
The API won't accept update requests with more than 500 update actions. With more than 400 actions in one request an warning will be logged. By more than 500 update actions an exception is thrown